### PR TITLE
Add missing "get_python.sh" step in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ git clone https://github.com/o3de/o3de.git -b stabilization/2409
 cd $DEMO_BASE/o3de
 git lfs install
 git lfs pull
+python/get_python.sh
 scripts/o3de.sh register --this-engine
 ```
 


### PR DESCRIPTION
Minor readme update.

Adds `python/get_python.sh` that is required before registering the engine.