### PR TITLE
Fix for launching command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $DEMO_BASE/o3de/scripts/o3de.sh register -gp $DEMO_BASE/loft-arch-vis-sample/Gem
 cd $DEMO_BASE/rai-rosbot-xl-demo/Project
 cmake -B build/linux -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=TRUE -DLY_DISABLE_TEST_MODULES=ON
 cmake --build build/linux --config profile --target RAIROSBotXLDemo.Assets RAIROSBotXLDemo.GameLauncher
-$DEMO_BASE/rai-rosbot-xl-demo/Project/build/linux/bin/profile/RAIROSBotXLDemo.GameLauncher
+$DEMO_BASE/rai-rosbot-xl-demo/Project/build/linux/bin/profile/RAIROSBotXLDemo.GameLauncher -bg_ConnectToAssetProcessor=0
 ```
 
 ### Running the simulation


### PR DESCRIPTION
GameLauncher tries to connect with the asset processor and fails.

Added "-bg_ConnectToAssetProcessor=0" to the launch command.