### PR TITLE
Add lights; minor updates

### DIFF
--- a/Examples/navigation/config/navigation_params_humble.yaml
+++ b/Examples/navigation/config/navigation_params_humble.yaml
@@ -119,8 +119,8 @@ controller_server:
   ros__parameters:
     use_sim_time: true
     controller_frequency: 5.0
-    min_x_velocity_threshold: 0.01    # Measured
-    min_y_velocity_threshold: 0.01    # Measured
+    min_x_velocity_threshold: 0.01 # Measured
+    min_y_velocity_threshold: 0.01 # Measured
     min_theta_velocity_threshold: 0.5 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
@@ -166,8 +166,17 @@ controller_server:
         time_step: 5
       AckermannConstrains:
         min_turning_r: 0.05
-      critics: [ConstraintCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic,
-        PathAngleCritic, PreferForwardCritic]
+      critics:
+        [
+          ConstraintCritic,
+          ObstaclesCritic,
+          GoalCritic,
+          GoalAngleCritic,
+          PathAlignCritic,
+          PathFollowCritic,
+          PathAngleCritic,
+          PreferForwardCritic,
+        ]
       ConstraintCritic:
         enabled: true
         cost_power: 1
@@ -240,7 +249,7 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: "[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]"
       plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
@@ -265,7 +274,6 @@ local_costmap:
         enabled: true
         cost_scaling_factor: 3.0
         inflation_radius: 1.0
-
       always_send_full_costmap: true
 
   local_costmap_client:
@@ -283,7 +291,11 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: true
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      width: 40
+      height: 40
+      origin_x: -20.0
+      origin_y: -20.0
+      footprint: "[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]"
       resolution: 0.05
       track_unknown_space: true
       plugins: [static_layer, obstacle_layer, inflation_layer]
@@ -391,7 +403,6 @@ behavior_server:
 
 slam_toolbox:
   ros__parameters:
-
     # Plugin params
     solver_plugin: solver_plugins::CeresSolver
     ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
@@ -483,114 +494,10 @@ velocity_smoother:
     smoothing_frequency: 5.0
     scale_velocities: false
     feedback: OPEN_LOOP
-    max_velocity: [0.5, 0.0, 1.5]   # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
+    max_velocity: [0.5, 0.0, 1.5] # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
     min_velocity: [-0.5, 0.0, -1.5] # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
     max_accel: [1.0, 0.0, 3.2]
-    max_decel: [-1.0, 0.0, -3.2]  # Measured
-    # used in the CLOSED_LOOP feedback mode
-    # odom_topic: "odometry/filtered"
-    odom_duration: 0.1
-    deadband_velocity: [0.01, 0.01, 0.1] # Measured
-    velocity_timeout: 1.0
-
-slam_toolbox:
-  ros__parameters:
-
-    # Plugin params
-    solver_plugin: solver_plugins::CeresSolver
-    ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
-    ceres_preconditioner: SCHUR_JACOBI
-    ceres_trust_strategy: LEVENBERG_MARQUARDT
-    ceres_dogleg_type: TRADITIONAL_DOGLEG
-    ceres_loss_function: None
-
-    # ROS Parameters
-    odom_frame: odom
-    map_frame: map
-    base_frame: base_link
-    scan_topic: scan
-    use_map_saver: true
-    mode: mapping #localization
-
-    # lifelong params
-    lifelong_search_use_tree: false
-    lifelong_minimum_score: 0.1
-    lifelong_iou_match: 0.85
-    lifelong_node_removal_score: 0.04
-    lifelong_overlap_score_scale: 0.06
-    lifelong_constraint_multiplier: 0.08
-    lifelong_nearby_penalty: 0.001
-    lifelong_candidates_scale: 0.03
-
-    debug_logging: false
-    throttle_scans: 1
-    transform_publish_period: 0.04
-    map_update_interval: 3.0
-    resolution: 0.05
-    max_laser_range: 12.0 #for rastering images
-    minimum_time_interval: 0.5
-    transform_timeout: 0.2
-    tf_buffer_duration: 10.
-    stack_size_to_use: 40000000 #// program needs a larger stack size to serialize large maps
-
-    # General Parameters
-    use_scan_matching: true
-    use_scan_barycenter: true
-    minimum_travel_distance: 0.4
-    minimum_travel_heading: 0.5
-    scan_buffer_size: 10
-    scan_buffer_maximum_scan_distance: 10.0
-    link_match_minimum_response_fine: 0.1
-    link_scan_maximum_distance: 1.5
-    loop_search_maximum_distance: 3.0
-    do_loop_closing: true
-    loop_match_minimum_chain_size: 10
-    loop_match_maximum_variance_coarse: 3.0
-    loop_match_minimum_response_coarse: 0.35
-    loop_match_minimum_response_fine: 0.45
-
-    # Correlation Parameters - Correlation Parameters
-    correlation_search_space_dimension: 0.5
-    correlation_search_space_resolution: 0.01
-    correlation_search_space_smear_deviation: 0.1
-
-    # Correlation Parameters - Loop Closure Parameters
-    loop_search_space_dimension: 8.0
-    loop_search_space_resolution: 0.05
-    loop_search_space_smear_deviation: 0.03
-
-    # Scan Matcher Parameters
-    distance_variance_penalty: 0.5
-    angle_variance_penalty: 1.0
-
-    fine_search_angle_offset: 0.00349
-    coarse_search_angle_offset: 0.349
-    coarse_angle_resolution: 0.0349
-    minimum_angle_penalty: 0.9
-    minimum_distance_penalty: 0.5
-    use_response_expansion: true
-
-waypoint_follower:
-  ros__parameters:
-    loop_rate: 5
-    stop_on_failure: false
-    waypoint_task_executor_plugin: wait_at_waypoint
-    wait_at_waypoint:
-      plugin: nav2_waypoint_follower::WaitAtWaypoint
-      enabled: true
-      waypoint_pause_duration: 200
-
-velocity_smoother:
-  ros__parameters:
-    use_sim_time: true
-
-    smoothing_frequency: 5.0
-    scale_velocities: false
-    feedback: OPEN_LOOP
-    max_velocity: [0.5, 0.0, 1.5]   # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
-    min_velocity: [-0.5, 0.0, -1.5] # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
-    max_accel: [1.0, 0.0, 3.2]
-    max_decel: [-1.0, 0.0, -3.2]  # Measured
+    max_decel: [-1.0, 0.0, -3.2] # Measured
     # used in the CLOSED_LOOP feedback mode
     # odom_topic: "odometry/filtered"
     odom_duration: 0.1

--- a/Examples/navigation/config/navigation_params_jazzy.yaml
+++ b/Examples/navigation/config/navigation_params_jazzy.yaml
@@ -91,8 +91,8 @@ controller_server:
   ros__parameters:
     use_sim_time: true
     controller_frequency: 5.0
-    min_x_velocity_threshold: 0.01    # Measured
-    min_y_velocity_threshold: 0.01    # Measured
+    min_x_velocity_threshold: 0.01 # Measured
+    min_y_velocity_threshold: 0.01 # Measured
     min_theta_velocity_threshold: 0.5 # Measured
     progress_checker_plugin: progress_checker
     goal_checker_plugin: goal_checker
@@ -138,8 +138,17 @@ controller_server:
         time_step: 5
       AckermannConstrains:
         min_turning_r: 0.05
-      critics: [ConstraintCritic, ObstaclesCritic, GoalCritic, GoalAngleCritic, PathAlignCritic, PathFollowCritic,
-        PathAngleCritic, PreferForwardCritic]
+      critics:
+        [
+          ConstraintCritic,
+          ObstaclesCritic,
+          GoalCritic,
+          GoalAngleCritic,
+          PathAlignCritic,
+          PathFollowCritic,
+          PathAngleCritic,
+          PreferForwardCritic,
+        ]
       ConstraintCritic:
         enabled: true
         cost_power: 1
@@ -208,7 +217,7 @@ local_costmap:
       width: 4
       height: 4
       resolution: 0.04
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: "[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]"
       plugins: [static_layer, obstacle_layer, inflation_layer]
       static_layer:
         plugin: nav2_costmap_2d::StaticLayer
@@ -251,7 +260,11 @@ global_costmap:
       global_frame: map
       robot_base_frame: base_link
       use_sim_time: true
-      footprint: '[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]'
+      footprint: "[[0.165, 0.145], [0.165, -0.145], [-0.165, -0.145], [-0.165, 0.145]]"
+      width: 40
+      height: 40
+      origin_x: -20.0
+      origin_y: -20.0
       resolution: 0.05
       track_unknown_space: true
       plugins: [static_layer, obstacle_layer, inflation_layer]
@@ -359,7 +372,6 @@ behavior_server:
 
 slam_toolbox:
   ros__parameters:
-
     # Plugin params
     solver_plugin: solver_plugins::CeresSolver
     ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
@@ -451,10 +463,10 @@ velocity_smoother:
     smoothing_frequency: 5.0
     scale_velocities: false
     feedback: OPEN_LOOP
-    max_velocity: [0.5, 0.0, 1.5]   # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
+    max_velocity: [0.5, 0.0, 1.5] # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
     min_velocity: [-0.5, 0.0, -1.5] # Measured: MAX[1.0, 0.0, 3.14] (decreased for safety)
     max_accel: [1.0, 0.0, 3.2]
-    max_decel: [-1.0, 0.0, -3.2]  # Measured
+    max_decel: [-1.0, 0.0, -3.2] # Measured
     # used in the CLOSED_LOOP feedback mode
     # odom_topic: "odometry/filtered"
     odom_duration: 0.1
@@ -464,23 +476,23 @@ velocity_smoother:
 docking_server:
   ros__parameters:
     # Types of docks
-    dock_plugins: ['nova_carter_dock']
+    dock_plugins: ["nova_carter_dock"]
     nova_carter_dock:
-      plugin: 'opennav_docking::SimpleChargingDock'
+      plugin: "opennav_docking::SimpleChargingDock"
       # More parameters exist here that we will discuss later in the tutorial
 
     # Dock instances
-    docks: ['home_dock','flex_dock1', 'flex_dock2']
+    docks: ["home_dock", "flex_dock1", "flex_dock2"]
     home_dock:
-      type: 'nova_carter_dock'
+      type: "nova_carter_dock"
       frame: map
       pose: [0.0, 0.0, 0.0]
     flex_dock1:
-      type: 'nova_carter_dock'
+      type: "nova_carter_dock"
       frame: map
       pose: [10.0, 10.0, 0.0]
     flex_dock2:
-      type: 'nova_carter_dock'
+      type: "nova_carter_dock"
       frame: map
       pose: [30.0, 30.0, 0.0]
 
@@ -542,7 +554,7 @@ collision_monitor:
       type: "circle"
       radius: 0.3
       action_type: "stop"
-      min_points: 4  # max_points: 3 for Humble
+      min_points: 4 # max_points: 3 for Humble
       visualize: True
       polygon_pub_topic: "polygon_stop"
       enabled: False
@@ -550,7 +562,7 @@ collision_monitor:
       type: "polygon"
       points: "[[1.0, 1.0], [1.0, -1.0], [-0.5, -1.0], [-0.5, 1.0]]"
       action_type: "slowdown"
-      min_points: 4  # max_points: 3 for Humble
+      min_points: 4 # max_points: 3 for Humble
       slowdown_ratio: 0.3
       visualize: True
       polygon_pub_topic: "polygon_slowdown"
@@ -559,7 +571,7 @@ collision_monitor:
       type: "polygon"
       points: "[[0.5, 0.5], [0.5, -0.5], [-0.5, -0.5], [-0.5, 0.5]]"
       action_type: "limit"
-      min_points: 4  # max_points: 3 for Humble
+      min_points: 4 # max_points: 3 for Humble
       linear_limit: 0.4
       angular_limit: 0.5
       visualize: True
@@ -571,7 +583,7 @@ collision_monitor:
       footprint_topic: "/local_costmap/published_footprint"
       time_before_collision: 2.0
       simulation_time_step: 0.02
-      min_points: 6  # max_points: 5 for Humble
+      min_points: 6 # max_points: 5 for Humble
       visualize: False
       enabled: False
     VelocityPolygonStop:
@@ -581,7 +593,8 @@ collision_monitor:
       visualize: True
       enabled: False
       polygon_pub_topic: "velocity_polygon_stop"
-      velocity_polygons: ["rotation", "translation_forward", "translation_backward", "stopped"]
+      velocity_polygons:
+        ["rotation", "translation_forward", "translation_backward", "stopped"]
       holonomic: false
       rotation:
         points: "[[0.3, 0.3], [0.3, -0.3], [-0.3, -0.3], [-0.3, 0.3]]"

--- a/patches/LEDStrip.cpp
+++ b/patches/LEDStrip.cpp
@@ -1,0 +1,132 @@
+
+#include "LEDStrip.h"
+
+#include <Atom/Feature/CoreLights/PhotometricValue.h>
+#include <AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/Math/Color.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <ROS2/Communication/QoS.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/Utilities/ROS2Names.h>
+
+namespace Husarion
+{
+    LEDStrip::LEDStrip()
+    {
+        m_topicConfiguration.m_topic = "led_strip";
+        m_topicConfiguration.m_type = "sensor_msgs/msg/image";
+    }
+
+    void LEDStrip::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<LEDStrip>()
+                ->Version(1)
+                ->Field("Leds", &LEDStrip::m_leds)
+                ->Field("intensity", &LEDStrip::m_intensity)
+                ->Field("TopicConfiguration", &LEDStrip::m_topicConfiguration);
+
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<LEDStrip>("LEDStrip", "LED Strip")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "Husarion")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &LEDStrip::m_intensity, "Intensity", "Intensity")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &LEDStrip::m_leds, "LEDs", "LEDs")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &LEDStrip::m_topicConfiguration, "Topic Configuration", "Topic Configuration");
+            }
+        }
+    }
+
+    void LEDStrip::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
+    void LEDStrip::Activate()
+    {
+        auto node = ROS2::ROS2Interface::Get()->GetNode();
+        if (!node)
+        {
+            AZ_Error("LightController", false, "ROS2 node is not available. Component will not be activated.");
+            return;
+        }
+
+        auto* ros2Frame = ROS2::Utils::GetGameOrEditorComponent<ROS2::ROS2FrameComponent>(GetEntity());
+        if (!ros2Frame)
+        {
+            AZ_Error("LightController", false, "ROS2FrameComponent is not available. Component will not be activated.");
+            return;
+        }
+
+        AZStd::string topicName = ROS2::ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), m_topicConfiguration.m_topic);
+
+        m_subscription = node->create_subscription<sensor_msgs::msg::Image>(
+            topicName.c_str(),
+            m_topicConfiguration.GetQoS(),
+            [this](const sensor_msgs::msg::Image::SharedPtr msg)
+            {
+                if (msg->encoding.c_str() != AZStd::string("8UC1"))
+                {
+                    AZ_Error("Husarion - LED strip", false, "Unsupported image encoding. Only 8UC1 is supported.");
+                    return;
+                }
+                if (msg->width != 3)
+                {
+                    AZ_Error("Husarion - LED strip", false, "Unsupported image width. Only 3 is supported.");
+                    return;
+                }
+                if (msg->height != 18)
+                {
+                    AZ_Error("Husarion - LED strip", false, "Unsupported image height. Only 18 is supported.");
+                    return;
+                }
+
+                for (int h = 0; h < msg->height; ++h)
+                {
+                    AZ::u8 red = msg->data[h * msg->step + 0];
+                    AZ::u8 green = msg->data[h * msg->step + 1];
+                    AZ::u8 blue = msg->data[h * msg->step + 2];
+
+                    AZ::Color lightColor(red, green, blue, 255);
+                    if (m_lightSet.contains(h))
+                    {
+                        AZ::Render::AreaLightRequestBus::Event(
+                            m_lightSet[h], &AZ::Render::AreaLightRequestBus::Events::SetColor, lightColor);
+                    }
+                }
+            });
+
+        m_lightSet.clear();
+        for (auto& led : m_leds)
+        {
+            m_lightSet[led.first] = led.second;
+        }
+
+        AZ::SystemTickBus::QueueFunction(
+            [this]()
+            {
+                for (auto& led : m_leds)
+                {
+                    AZ::Render::AreaLightRequestBus::Event(
+                        led.second,
+                        &AZ::Render::AreaLightRequestBus::Events::SetIntensityAndMode,
+                        m_intensity,
+                        AZ::Render::PhotometricUnit::Lumen);
+                }
+            });
+    }
+
+    void LEDStrip::Deactivate()
+    {
+        m_subscription.reset();
+    }
+} // namespace Husarion

--- a/patches/LEDStrip.cpp
+++ b/patches/LEDStrip.cpp
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Robotec.ai.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 
 #include "LEDStrip.h"
 

--- a/patches/LEDStrip.h
+++ b/patches/LEDStrip.h
@@ -6,6 +6,7 @@
 #include <AzCore/std/containers/map.h>
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <rclcpp/subscription.hpp>
+#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/detail/image__struct.hpp>
 #include <sensor_msgs/msg/image.hpp>
 

--- a/patches/LEDStrip.h
+++ b/patches/LEDStrip.h
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/std/containers/map.h>
+#include <ROS2/Communication/TopicConfiguration.h>
+#include <rclcpp/subscription.hpp>
+#include <sensor_msgs/msg/detail/image__struct.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+namespace Husarion
+{
+    class LEDStrip : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(LEDStrip, "{6C2D9FCD-3204-4457-B4A5-1594D94409C8}");
+        LEDStrip();
+        ~LEDStrip() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+        AZStd::vector<AZStd::pair<int, AZ::EntityId>> m_leds;
+        float m_intensity = 1.0f;
+        AZStd::map<int, AZ::EntityId> m_lightSet;
+
+        ROS2::TopicConfiguration m_topicConfiguration;
+        rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr m_subscription;
+    };
+} // namespace Husarion

--- a/patches/LEDStrip.h
+++ b/patches/LEDStrip.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Robotec.ai.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 
 #pragma once
 

--- a/patches/updates.patch
+++ b/patches/updates.patch
@@ -11,8 +11,116 @@ index c176865..b4cd5e9 100644
          LANGUAGES C CXX
          VERSION 1.0.0.0
      )
+diff --git a/Gem/CMakeLists.txt b/Gem/CMakeLists.txt
+index 9ebe917..38aa909 100644
+--- a/Gem/CMakeLists.txt
++++ b/Gem/CMakeLists.txt
+@@ -55,11 +55,17 @@ ly_add_target(
+         PUBLIC
+             Include
+     BUILD_DEPENDENCIES
++        PUBLIC
++            Gem::ROS2.Static
+         PRIVATE
++            AtomLyIntegration_CommonFeatures.Public
+             AZ::AzGameFramework
+             Gem::Atom_AtomBridge.Static
+ )
+ 
++# Request ROS2 packages to be included 
++target_depends_on_ros2_packages(${gem_name}.Static rclcpp tf2 std_msgs sensor_msgs)
++
+ ly_add_target(
+     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+     NAMESPACE Gem
+diff --git a/Gem/Source/RobotVacuumSampleModule.cpp b/Gem/Source/RobotVacuumSampleModule.cpp
+index f9f3ecd..9aedbe6 100644
+--- a/Gem/Source/RobotVacuumSampleModule.cpp
++++ b/Gem/Source/RobotVacuumSampleModule.cpp
+@@ -1,6 +1,7 @@
+ /*
+  * Copyright (c) Contributors to the Open 3D Engine Project.
+- * For complete copyright and license terms please see the LICENSE at the root of this distribution.
++ * For complete copyright and license terms please see the LICENSE at the root
++ * of this distribution.
+  *
+  * SPDX-License-Identifier: Apache-2.0 OR MIT
+  *
+@@ -9,36 +10,34 @@
+ #include <AzCore/Memory/SystemAllocator.h>
+ #include <AzCore/Module/Module.h>
+ 
++#include "LEDStrip/LEDStrip.h"
+ #include "RobotVacuumSampleSystemComponent.h"
+ 
+-namespace RobotVacuumSample
+-{
+-    class RobotVacuumSampleModule
+-        : public AZ::Module
+-    {
+-    public:
+-        AZ_RTTI(RobotVacuumSampleModule, "{0ea31247-8ee5-491d-93cb-296a6c91c995}", AZ::Module);
+-        AZ_CLASS_ALLOCATOR(RobotVacuumSampleModule, AZ::SystemAllocator, 0);
++namespace RobotVacuumSample {
++class RobotVacuumSampleModule : public AZ::Module {
++public:
++  AZ_RTTI(RobotVacuumSampleModule, "{0ea31247-8ee5-491d-93cb-296a6c91c995}",
++          AZ::Module);
++  AZ_CLASS_ALLOCATOR(RobotVacuumSampleModule, AZ::SystemAllocator, 0);
+ 
+-        RobotVacuumSampleModule()
+-            : AZ::Module()
+-        {
+-            // Push results of RobotVacuumSampleSystemComponent::CreateDescriptor() into m_descriptors here.
+-            m_descriptors.insert(m_descriptors.end(), {
+-                RobotVacuumSampleSystemComponent::CreateDescriptor(),
+-            });
+-        }
++  RobotVacuumSampleModule() : AZ::Module() {
++    // Push results of RobotVacuumSampleSystemComponent::CreateDescriptor() into
++    // m_descriptors here.
++    m_descriptors.insert(m_descriptors.end(),
++                         {RobotVacuumSampleSystemComponent::CreateDescriptor(),
++                          Husarion::LEDStrip::CreateDescriptor()});
++  }
+ 
+-        /**
+-         * Add required SystemComponents to the SystemEntity.
+-         */
+-        AZ::ComponentTypeList GetRequiredSystemComponents() const override
+-        {
+-            return AZ::ComponentTypeList{
+-                azrtti_typeid<RobotVacuumSampleSystemComponent>(),
+-            };
+-        }
++  /**
++   * Add required SystemComponents to the SystemEntity.
++   */
++  AZ::ComponentTypeList GetRequiredSystemComponents() const override {
++    return AZ::ComponentTypeList{
++        azrtti_typeid<RobotVacuumSampleSystemComponent>(),
+     };
+-}// namespace RobotVacuumSample
++  }
++};
++} // namespace RobotVacuumSample
+ 
+-AZ_DECLARE_MODULE_CLASS(Gem_RobotVacuumSample, RobotVacuumSample::RobotVacuumSampleModule)
++AZ_DECLARE_MODULE_CLASS(Gem_RobotVacuumSample,
++                        RobotVacuumSample::RobotVacuumSampleModule)
+diff --git a/Gem/robot_vacuum_sample_files.cmake b/Gem/robot_vacuum_sample_files.cmake
+index 2382d00..129fa99 100644
+--- a/Gem/robot_vacuum_sample_files.cmake
++++ b/Gem/robot_vacuum_sample_files.cmake
+@@ -10,4 +10,6 @@ set(FILES
+     Include/RobotVacuumSample/RobotVacuumSampleBus.h
+     Source/RobotVacuumSampleSystemComponent.cpp
+     Source/RobotVacuumSampleSystemComponent.h
++    Source/LEDStrip/LEDStrip.cpp
++    Source/LEDStrip/LEDStrip.h
+ )
 diff --git a/Levels/Loft/Loft.prefab b/Levels/Loft/Loft.prefab
-index 84d0bfa..638320b 100644
+index 84d0bfa..19882a5 100644
 --- a/Levels/Loft/Loft.prefab
 +++ b/Levels/Loft/Loft.prefab
 @@ -24,7 +24,7 @@
@@ -49,7 +157,7 @@ index 84d0bfa..638320b 100644
                          ]
                      }
                  },
-@@ -5184,6 +5191,310 @@
+@@ -5184,6 +5191,1153 @@
                  }
              ]
          },
@@ -75,36 +183,6 @@ index 84d0bfa..638320b 100644
 +                    "op": "replace",
 +                    "path": "/ContainerEntity/Components/Component_[959982562508610]/Transform Data/Translate/2",
 +                    "value": -0.015290498733520508
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/0",
-+                    "value": -0.9476395845413208
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/1",
-+                    "value": 0.7084693908691406
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/2",
-+                    "value": 1.4535069465637207
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/0",
-+                    "value": 35.423553466796875
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/1",
-+                    "value": 37.78596115112305
-+                },
-+                {
-+                    "op": "replace",
-+                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/2",
-+                    "value": -139.2576904296875
 +                },
 +                {
 +                    "op": "replace",
@@ -178,6 +256,11 @@ index 84d0bfa..638320b 100644
 +                },
 +                {
 +                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[7507839849146]/Components/Component_[6563269519356188309]/Child Entity Order/11",
++                    "value": "Entity_[3606091082346]"
++                },
++                {
++                    "op": "add",
 +                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[7507839849146]/Components/ROS2OdometrySensorComponent",
 +                    "value": {
 +                        "$type": "GenericComponentWrapper",
@@ -203,6 +286,36 @@ index 84d0bfa..638320b 100644
 +                            }
 +                        }
 +                    }
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/0",
++                    "value": -0.9476395845413208
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/1",
++                    "value": 0.7084693908691406
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Translate/2",
++                    "value": 1.4535069465637207
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/0",
++                    "value": 35.423553466796875
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/1",
++                    "value": 37.78596115112305
++                },
++                {
++                    "op": "replace",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[969892482106]/Components/Component_[6043040033160946649]/Transform Data/Rotate/2",
++                    "value": -139.2576904296875
 +                },
 +                {
 +                    "op": "add",
@@ -354,13 +467,851 @@ index 84d0bfa..638320b 100644
 +                        },
 +                        "IsRuntimeActive": true
 +                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[3649040755306]",
++                    "value": {
++                        "Id": "Entity_[3649040755306]",
++                        "Name": "leds",
++                        "Components": {
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 15071823821030689239,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 12623198857769754115,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 4857731609615443601,
++                                "Child Entity Order": [
++                                    "Entity_[9434361703018]",
++                                    "Entity_[9447246604906]",
++                                    "Entity_[9460131506794]",
++                                    "Entity_[9473016408682]"
++                                ]
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 13422624070651342938,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 3114821448912022272,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 2712868098646940842,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 12526528997120917520,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 6586465844210358749,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 10650662857206251744,
++                                "Parent Entity": "Entity_[3606091082346]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[3606091082346]",
++                    "value": {
++                        "Id": "Entity_[3606091082346]",
++                        "Name": "led_strip",
++                        "Components": {
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 358974090853920534,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 4500976765967299734,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 13391621620028539532,
++                                "Child Entity Order": [
++                                    "Entity_[3649040755306]",
++                                    "Entity_[3627565918826]"
++                                ]
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 2483252120585929723,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 8778037404539399630,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 16517322563544690698,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 867632201357196864,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 9340059878917549910,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 5498112490028320794,
++                                "Parent Entity": "Entity_[7507839849146]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[3627565918826]",
++                    "value": {
++                        "Id": "Entity_[3627565918826]",
++                        "Name": "controller",
++                        "Components": {
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 73606627681706617,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 9850914634082375354,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 8361868025467468251,
++                                "Child Entity Order": []
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 3639945120187319927,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 10336729595102159302,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 1786143438013267150,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 9563892481362695584,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 7783387967197486627,
++                                "VisibilityFlag": true
++                            },
++                            "LEDStrip": {
++                                "$type": "GenericComponentWrapper",
++                                "Id": 4193157760936481090,
++                                "m_template": {
++                                    "$type": "LEDStrip",
++                                    "Leds": [
++                                        [
++                                            0,
++                                            "Entity_[9434361703018]"
++                                        ],
++                                        [
++                                            3,
++                                            "Entity_[9447246604906]"
++                                        ],
++                                        [
++                                            8,
++                                            "Entity_[9460131506794]"
++                                        ],
++                                        [
++                                            13,
++                                            "Entity_[9473016408682]"
++                                        ]
++                                    ],
++                                    "intensity": 10.0,
++                                    "TopicConfiguration": {
++                                        "Type": "sensor_msgs/msg/image",
++                                        "Topic": "led_strip",
++                                        "QoS": {
++                                            "Reliability": 2,
++                                            "Durability": 2,
++                                            "Depth": 5
++                                        }
++                                    }
++                                }
++                            },
++                            "ROS2FrameEditorComponent": {
++                                "$type": "ROS2FrameEditorComponent",
++                                "Id": 16913189684188927069,
++                                "ROS2FrameConfiguration": {
++                                    "Namespace Configuration": {
++                                        "Namespace Strategy": 0,
++                                        "Namespace": ""
++                                    },
++                                    "Frame Name": "leds_frame",
++                                    "Joint Name": "",
++                                    "Publish Transform": true
++                                }
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 14247401117521865335,
++                                "Parent Entity": "Entity_[3606091082346]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[9434361703018]",
++                    "value": {
++                        "Id": "Entity_[9434361703018]",
++                        "Name": "0",
++                        "Components": {
++                            "AZ::Render::EditorAreaLightComponent": {
++                                "$type": "AZ::Render::EditorAreaLightComponent",
++                                "Id": 12394459173116108458,
++                                "Controller": {
++                                    "Configuration": {
++                                        "LightType": 6,
++                                        "Color": [
++                                            1.0,
++                                            1.0,
++                                            1.0,
++                                            1.0
++                                        ],
++                                        "IntensityMode": 0,
++                                        "Intensity": 10.0,
++                                        "AttenuationRadiusMode": 1,
++                                        "AttenuationRadius": 10.0,
++                                        "LightEmitsBothDirections": false,
++                                        "UseFastApproximation": false,
++                                        "GoboAsset": {
++                                            "assetId": {
++                                                "guid": "{00000000-0000-0000-0000-000000000000}",
++                                                "subId": 0
++                                            },
++                                            "loadBehavior": "QueueLoad",
++                                            "assetHint": ""
++                                        },
++                                        "EnableShutters": false,
++                                        "InnerShutterAngleDegrees": 35.0,
++                                        "OuterShutterAngleDegrees": 45.0,
++                                        "Enable Shadow": false,
++                                        "Shadow Bias": 0.10000000149011612,
++                                        "Normal Shadow Bias": 0.0,
++                                        "Shadowmap Max Size": "Size256",
++                                        "Shadow Filter Method": 0,
++                                        "Filtering Sample Count": 12,
++                                        "Esm Exponent": 87.0,
++                                        "Shadow Caching Mode": 0,
++                                        "Shadow Caching Enabled": false,
++                                        "Affects GI": true,
++                                        "Affects GI Factor": 1.0,
++                                        "LightingChannelConfig": {
++                                            "lightingChannelFlags": [
++                                                true,
++                                                false,
++                                                false,
++                                                false,
++                                                false
++                                            ]
++                                        }
++                                    }
++                                }
++                            },
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 10571022605550247935,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 15457741460261428369,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 1587810564424441331,
++                                "Child Entity Order": []
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 10665050593086246330,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 9290445237659683303,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 4562205387857782953,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 8274512652100027097,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 2822223100445109902,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 1798644683938016943,
++                                "Parent Entity": "Entity_[3649040755306]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        0.08500000089406967,
++                                        0.12400007247924805,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[9447246604906]",
++                    "value": {
++                        "Id": "Entity_[9447246604906]",
++                        "Name": "1",
++                        "Components": {
++                            "AZ::Render::EditorAreaLightComponent": {
++                                "$type": "AZ::Render::EditorAreaLightComponent",
++                                "Id": 5084503850939111940,
++                                "Controller": {
++                                    "Configuration": {
++                                        "LightType": 6,
++                                        "Color": [
++                                            1.0,
++                                            1.0,
++                                            1.0,
++                                            1.0
++                                        ],
++                                        "IntensityMode": 0,
++                                        "Intensity": 10.0,
++                                        "AttenuationRadiusMode": 1,
++                                        "AttenuationRadius": 10.0,
++                                        "LightEmitsBothDirections": false,
++                                        "UseFastApproximation": false,
++                                        "GoboAsset": {
++                                            "assetId": {
++                                                "guid": "{00000000-0000-0000-0000-000000000000}",
++                                                "subId": 0
++                                            },
++                                            "loadBehavior": "QueueLoad",
++                                            "assetHint": ""
++                                        },
++                                        "EnableShutters": false,
++                                        "InnerShutterAngleDegrees": 35.0,
++                                        "OuterShutterAngleDegrees": 45.0,
++                                        "Enable Shadow": false,
++                                        "Shadow Bias": 0.10000000149011612,
++                                        "Normal Shadow Bias": 0.0,
++                                        "Shadowmap Max Size": "Size256",
++                                        "Shadow Filter Method": 0,
++                                        "Filtering Sample Count": 12,
++                                        "Esm Exponent": 87.0,
++                                        "Shadow Caching Mode": 0,
++                                        "Shadow Caching Enabled": false,
++                                        "Affects GI": true,
++                                        "Affects GI Factor": 1.0,
++                                        "LightingChannelConfig": {
++                                            "lightingChannelFlags": [
++                                                true,
++                                                false,
++                                                false,
++                                                false,
++                                                false
++                                            ]
++                                        }
++                                    }
++                                }
++                            },
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 16955444659223176499,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 11568557911039021133,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 15855137193404472075,
++                                "Child Entity Order": []
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 14701485340091696432,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 3026296010401867535,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 6457896215182501029,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 13787858217104134740,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 14036240229484776655,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 9457184316297870899,
++                                "Parent Entity": "Entity_[3649040755306]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        -0.08500000834465027,
++                                        0.12400007247924805,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[9460131506794]",
++                    "value": {
++                        "Id": "Entity_[9460131506794]",
++                        "Name": "2",
++                        "Components": {
++                            "AZ::Render::EditorAreaLightComponent": {
++                                "$type": "AZ::Render::EditorAreaLightComponent",
++                                "Id": 1872869779958382644,
++                                "Controller": {
++                                    "Configuration": {
++                                        "LightType": 6,
++                                        "Color": [
++                                            1.0,
++                                            1.0,
++                                            1.0,
++                                            1.0
++                                        ],
++                                        "IntensityMode": 0,
++                                        "Intensity": 10.0,
++                                        "AttenuationRadiusMode": 1,
++                                        "AttenuationRadius": 10.0,
++                                        "LightEmitsBothDirections": false,
++                                        "UseFastApproximation": false,
++                                        "GoboAsset": {
++                                            "assetId": {
++                                                "guid": "{00000000-0000-0000-0000-000000000000}",
++                                                "subId": 0
++                                            },
++                                            "loadBehavior": "QueueLoad",
++                                            "assetHint": ""
++                                        },
++                                        "EnableShutters": false,
++                                        "InnerShutterAngleDegrees": 35.0,
++                                        "OuterShutterAngleDegrees": 45.0,
++                                        "Enable Shadow": false,
++                                        "Shadow Bias": 0.10000000149011612,
++                                        "Normal Shadow Bias": 0.0,
++                                        "Shadowmap Max Size": "Size256",
++                                        "Shadow Filter Method": 0,
++                                        "Filtering Sample Count": 12,
++                                        "Esm Exponent": 87.0,
++                                        "Shadow Caching Mode": 0,
++                                        "Shadow Caching Enabled": false,
++                                        "Affects GI": true,
++                                        "Affects GI Factor": 1.0,
++                                        "LightingChannelConfig": {
++                                            "lightingChannelFlags": [
++                                                true,
++                                                false,
++                                                false,
++                                                false,
++                                                false
++                                            ]
++                                        }
++                                    }
++                                }
++                            },
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 2192432043622460722,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 1955543767624876406,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 14461964326941844986,
++                                "Child Entity Order": []
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 3619191778669783668,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 10477301891743903278,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 16577441298435236804,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 6325085944862632706,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 8030426203525656530,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 12125691264133961955,
++                                "Parent Entity": "Entity_[3649040755306]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        -0.08500000834465027,
++                                        -0.12400007247924805,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
++                },
++                {
++                    "op": "add",
++                    "path": "/Instances/Instance_[3732164110801]/Entities/Entity_[9473016408682]",
++                    "value": {
++                        "Id": "Entity_[9473016408682]",
++                        "Name": "3",
++                        "Components": {
++                            "AZ::Render::EditorAreaLightComponent": {
++                                "$type": "AZ::Render::EditorAreaLightComponent",
++                                "Id": 11044176309950472526,
++                                "Controller": {
++                                    "Configuration": {
++                                        "LightType": 6,
++                                        "Color": [
++                                            1.0,
++                                            1.0,
++                                            1.0,
++                                            1.0
++                                        ],
++                                        "IntensityMode": 0,
++                                        "Intensity": 10.0,
++                                        "AttenuationRadiusMode": 1,
++                                        "AttenuationRadius": 10.0,
++                                        "LightEmitsBothDirections": false,
++                                        "UseFastApproximation": false,
++                                        "GoboAsset": {
++                                            "assetId": {
++                                                "guid": "{00000000-0000-0000-0000-000000000000}",
++                                                "subId": 0
++                                            },
++                                            "loadBehavior": "QueueLoad",
++                                            "assetHint": ""
++                                        },
++                                        "EnableShutters": false,
++                                        "InnerShutterAngleDegrees": 35.0,
++                                        "OuterShutterAngleDegrees": 45.0,
++                                        "Enable Shadow": false,
++                                        "Shadow Bias": 0.10000000149011612,
++                                        "Normal Shadow Bias": 0.0,
++                                        "Shadowmap Max Size": "Size256",
++                                        "Shadow Filter Method": 0,
++                                        "Filtering Sample Count": 12,
++                                        "Esm Exponent": 87.0,
++                                        "Shadow Caching Mode": 0,
++                                        "Shadow Caching Enabled": false,
++                                        "Affects GI": true,
++                                        "Affects GI Factor": 1.0,
++                                        "LightingChannelConfig": {
++                                            "lightingChannelFlags": [
++                                                true,
++                                                false,
++                                                false,
++                                                false,
++                                                false
++                                            ]
++                                        }
++                                    }
++                                }
++                            },
++                            "EditorDisabledCompositionComponent": {
++                                "$type": "EditorDisabledCompositionComponent",
++                                "Id": 10146512577784384261,
++                                "DisabledComponents": []
++                            },
++                            "EditorEntityIconComponent": {
++                                "$type": "EditorEntityIconComponent",
++                                "Id": 13108387318856540249,
++                                "EntityIconAssetId": {
++                                    "guid": "{00000000-0000-0000-0000-000000000000}",
++                                    "subId": 0
++                                }
++                            },
++                            "EditorEntitySortComponent": {
++                                "$type": "EditorEntitySortComponent",
++                                "Id": 13870364035646590883,
++                                "Child Entity Order": []
++                            },
++                            "EditorInspectorComponent": {
++                                "$type": "EditorInspectorComponent",
++                                "Id": 4621491318588641955,
++                                "ComponentOrderEntryArray": []
++                            },
++                            "EditorLockComponent": {
++                                "$type": "EditorLockComponent",
++                                "Id": 3411221861312336842,
++                                "Locked": false
++                            },
++                            "EditorOnlyEntityComponent": {
++                                "$type": "EditorOnlyEntityComponent",
++                                "Id": 4823212550225557520,
++                                "IsEditorOnly": false
++                            },
++                            "EditorPendingCompositionComponent": {
++                                "$type": "EditorPendingCompositionComponent",
++                                "Id": 11085652077241097011,
++                                "PendingComponents": []
++                            },
++                            "EditorVisibilityComponent": {
++                                "$type": "EditorVisibilityComponent",
++                                "Id": 1474728677708586793,
++                                "VisibilityFlag": true
++                            },
++                            "TransformComponent": {
++                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
++                                "Id": 3140089982725808861,
++                                "Parent Entity": "Entity_[3649040755306]",
++                                "Transform Data": {
++                                    "Translate": [
++                                        0.08500000089406967,
++                                        -0.12400007247924805,
++                                        0.0
++                                    ],
++                                    "Rotate": [
++                                        0.0,
++                                        0.0,
++                                        0.0
++                                    ],
++                                    "Scale": [
++                                        1.0,
++                                        1.0,
++                                        1.0
++                                    ],
++                                    "Locked": false,
++                                    "UniformScale": 1.0
++                                },
++                                "Parent Activation Transform Mode": 0,
++                                "IsStatic": false,
++                                "InterpolatePosition": 0,
++                                "InterpolateRotation": 0
++                            }
++                        },
++                        "IsRuntimeActive": true
++                    }
 +                }
 +            ]
 +        },
          "Instance_[16288957418879]": {
              "Source": "Props/Kitchen_Refrigerator_MOD000016/refrigerator.prefab",
              "Patches": [
-@@ -5809,299 +6120,6 @@
+@@ -5809,299 +6963,6 @@
                  }
              ]
          },
@@ -661,7 +1612,7 @@ index 84d0bfa..638320b 100644
              "Source": "Props/Office_Desk_Chair_B082BLFMRC/office_desk_chair.prefab",
              "Patches": [
 diff --git a/project.json b/project.json
-index 94e8b34..8985c27 100644
+index 94e8b34..e961082 100644
 --- a/project.json
 +++ b/project.json
 @@ -1,22 +1,22 @@
@@ -692,15 +1643,18 @@ index 94e8b34..8985c27 100644
      "gem_names": [
          "ArchVis",
          "Atom",
-@@ -31,7 +31,9 @@
+@@ -31,7 +31,10 @@
          "ROS2>=3.1.0",
          "ScriptEvents",
          "StartingPointInput",
 -        "TextureAtlas"
 +        "TextureAtlas",
 +        "RosRobotSample",
-+        "DiffuseProbeGrid"
++        "DiffuseProbeGrid",
++        "RobotVacuumSample"
      ],
 -    "engine_version": "4.1.0"
+-}
 +    "engine_version": "2.2.1"
- }
++}
+\ No newline at end of file

--- a/setup_submodules.bash
+++ b/setup_submodules.bash
@@ -8,7 +8,7 @@ cd ./Project
 git lfs install
 git lfs pull
 
-git apply ../patches/updates.patch
+git apply --reject --whitespace=fix ../patches/updates.patch
 if [ $? -ne 0 ]
 then
 	echo "Failed to apply patch on a submodule."

--- a/setup_submodules.bash
+++ b/setup_submodules.bash
@@ -18,6 +18,9 @@ fi
 mkdir -p ./AssetBundling/SeedLists
 cp ../patches/husarion.seed ./AssetBundling/SeedLists
 
+mkdir -p Gem/Source/LEDStrip
+cp ../patches/LEDStrip.* Gem/Source/LEDStrip
+
 # Remove unused (ambiguous) files from the submodule
 rm -rf ./Assets/Importer/
 rm -rf ./Assets/RoboVac/


### PR DESCRIPTION
- add lights to the robot - four lights around the wheels
- the same protocol as in the real robot is used (1x18 image), but only 4 pixels are displayed (0, 3, 8, 13)
- clean up `navigation_params_humble` - the same piece of configuration was copied twice by mistake, this is fixed now
- add `width`, `height` and `offset` parameters to nav2 configuration files to global map
- add option to ignore whitespace when applying patch