### PR TITLE
chore: update rosbot-xl-whoami version

### DIFF
--- a/src/rosbot_xl_whoami/package.xml
+++ b/src/rosbot_xl_whoami/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rosbot_xl_whoami</name>
-  <version>0.0.0</version>
+  <version>1.0.0</version>
   <description>Package sharing information about the husarion robot.</description>
   <maintainer email="wiktoria.siekierska@robotec.ai">wsiekierska</maintainer>
   <license>Apache-2.0</license>

--- a/src/rosbot_xl_whoami/setup.py
+++ b/src/rosbot_xl_whoami/setup.py
@@ -7,7 +7,7 @@ package_name = "rosbot_xl_whoami"
 
 setup(
     name=package_name,
-    version="0.0.0",
+    version="1.0.0",
     packages=find_packages(exclude=["test"]),
     data_files=[
         (os.path.join("share", package_name, os.path.dirname(p)), [p])


### PR DESCRIPTION
Update whoami package version to reflect RAI's 1.0.0 release